### PR TITLE
fix: exclude tabs from ligature run shaping to stop text corruption

### DIFF
--- a/crates/scribe-renderer/src/atlas.rs
+++ b/crates/scribe-renderer/src/atlas.rs
@@ -240,6 +240,7 @@ pub struct GlyphAtlas {
     swash_cache: SwashCache,
     metrics: Metrics,
     cell_size: CellSize,
+    bold_cell_size: CellSize,
     atlas_size: u32,
     /// Owned family name; `None` means fall back to system monospace.
     family_name: Option<String>,
@@ -263,8 +264,14 @@ impl GlyphAtlas {
         let metrics = Metrics::new(params.size, line_height);
 
         // Measure the cell size by shaping "M" (a wide capital letter).
+        // Bold text is shaped with a distinct weight (`font_weight_bold`),
+        // which can have different glyph metrics than the regular weight, so
+        // it needs its own reference cell width — see `bold_cell_size`.
         let family = family_name_to_cosmic(family_name.as_deref());
-        let cell_size = measure_cell(&mut font_system, metrics, family, params.ligatures);
+        let cell_size =
+            measure_cell(&mut font_system, metrics, family, params.ligatures, params.weight);
+        let bold_cell_size =
+            measure_cell(&mut font_system, metrics, family, params.ligatures, params.weight_bold);
 
         // Create the atlas texture.
         let texture = device.create_texture(&TextureDescriptor {
@@ -303,6 +310,7 @@ impl GlyphAtlas {
             swash_cache,
             metrics,
             cell_size,
+            bold_cell_size,
             atlas_size: ATLAS_SIZE,
             family_name,
             font_weight: params.weight,
@@ -653,7 +661,9 @@ impl GlyphAtlas {
             Self::build_attrs_from(family_str, self.font_weight, self.font_weight_bold, style);
         buf.set_text(&mut self.font_system, text, &attrs, Shaping::Advanced, None);
 
-        let cell_w = self.cell_size.width;
+        // Glyphs in this run were shaped at `style`'s weight, so they must be
+        // measured against the cell width for that same weight.
+        let cell_w = if style.bold { self.bold_cell_size.width } else { self.cell_size.width };
         let mut glyphs = Vec::new();
         // Track column position incrementally instead of dividing g.x by cell_w.
         // The division-based approach accumulates floating-point drift across long
@@ -735,7 +745,13 @@ impl GlyphAtlas {
     /// left bearing.  Both the placeholders and the wide glyph fail this
     /// check, allowing [`build_ligature_map`] to merge them into a proper
     /// multi-cell ligature.
-    pub fn fits_single_cell(&mut self, cache_key: CacheKey) -> bool {
+    ///
+    /// `style` must match the style the glyph was shaped with — a bold glyph
+    /// is compared against `bold_cell_size`, since its metrics only align
+    /// with a cell width measured at the same weight. Comparing it against
+    /// the regular-weight cell width instead can make an ordinary single-cell
+    /// bold glyph spuriously fail this check.
+    pub fn fits_single_cell(&mut self, cache_key: CacheKey, style: GlyphStyle) -> bool {
         let image = self.swash_cache.get_image(&mut self.font_system, cache_key);
         let Some(img) = image.as_ref() else { return false };
 
@@ -743,7 +759,8 @@ impl GlyphAtlas {
             return false;
         }
 
-        let cell_w = i32::from(atlas_ceil_u16(self.cell_size.width));
+        let cell_size = if style.bold { self.bold_cell_size } else { self.cell_size };
+        let cell_w = i32::from(atlas_ceil_u16(cell_size.width));
         let max_left_extension = cell_w / 3;
         if img.placement.left < -max_left_extension {
             return false;
@@ -884,15 +901,24 @@ fn compute_uvs(px: u32, py: u32, uv_width: f32, uv_height: f32, atlas_size: u32)
     }
 }
 
-/// Measure cell dimensions by shaping the capital letter "M".
+/// Measure cell dimensions by shaping the capital letter "M" at `weight`.
+///
+/// Must be called once per distinct weight used for shaping (regular and
+/// bold): a glyph shaped at a given weight is only guaranteed to align with
+/// a cell width measured at that same weight. Reusing the regular-weight
+/// cell width to bound bold glyphs lets a bold glyph's advance legitimately
+/// exceed the regular "M" width, which `shape_run_uncached` and
+/// `fits_single_cell` misread as a multi-cell ligature glyph — corrupting
+/// the ligature map and dropping the following cell's character.
 fn measure_cell(
     font_system: &mut FontSystem,
     metrics: Metrics,
     family: Family<'_>,
     ligatures: bool,
+    weight: u16,
 ) -> CellSize {
     let mut buf = Buffer::new_empty(metrics);
-    let attrs = Attrs::new().family(family);
+    let attrs = Attrs::new().family(family).weight(cosmic_text::Weight(weight));
     let shaping = if ligatures { Shaping::Advanced } else { Shaping::Basic };
     buf.set_text(font_system, "M", &attrs, shaping, None);
 

--- a/crates/scribe-renderer/src/lib.rs
+++ b/crates/scribe-renderer/src/lib.rs
@@ -1145,14 +1145,18 @@ mod tests {
         assert_eq!(runs[1].start_col, 5);
     }
 
-    /// A lone tab with no adjacent same-run text on either side must not
-    /// surface as a one-character run (runs require >= 2 chars anyway, but
-    /// this pins down the tab-specific flush path doesn't special-case it).
+    /// A tab must not rescue a lone preceding character into a run by
+    /// attaching to it. The zero-width tab satisfies `RunAccum::matches`
+    /// against the single `a`, so without the flush it would append and
+    /// surface a spurious two-char `"a\t"` run; excluding the tab leaves
+    /// only the following word.
     #[test]
-    fn detect_styled_runs_drops_lone_leading_tab() {
-        let cells = cells_from_str(0, "\tx");
+    fn detect_styled_runs_tab_does_not_rescue_single_char() {
+        let cells = cells_from_str(0, "a\tbc");
         let runs = detect_styled_runs(&cells);
 
-        assert!(runs.is_empty());
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "bc");
+        assert_eq!(runs[0].start_col, 2);
     }
 }

--- a/crates/scribe-renderer/src/lib.rs
+++ b/crates/scribe-renderer/src/lib.rs
@@ -647,7 +647,7 @@ impl TerminalRenderer {
         c: char,
         flags: Flags,
     ) -> ([f32; 2], [f32; 2]) {
-        if c == ' ' || c == '\u{0}' {
+        if c == ' ' || c == '\t' || c == '\u{0}' {
             return ([0.0, 0.0], [0.0, 0.0]);
         }
 
@@ -672,7 +672,7 @@ impl TerminalRenderer {
         cell: CollectedCellKey,
         ligature_map: &LigatureMap,
     ) -> ([f32; 2], [f32; 2]) {
-        if cell.c == ' ' || cell.c == '\u{0}' {
+        if cell.c == ' ' || cell.c == '\t' || cell.c == '\u{0}' {
             return ([0.0, 0.0], [0.0, 0.0]);
         }
 
@@ -895,7 +895,8 @@ impl RunAccum {
 /// Group collected cells into contiguous same-styled runs suitable for
 /// ligature shaping.
 ///
-/// Wide-character spacer cells are skipped. Runs spanning a row change or a
+/// Wide-character spacer cells are skipped, and tabs flush the current run
+/// and are excluded rather than shaped. Runs spanning a row change or a
 /// style change (bold, italic, fg, bg) are flushed. Only runs with two or
 /// more characters are returned, since a single character cannot form a
 /// ligature.
@@ -908,6 +909,18 @@ fn detect_styled_runs(cells: &[CollectedCell]) -> Vec<StyledRun> {
         if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
             || cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)
         {
+            continue;
+        }
+
+        // Tabs are column separators, not shapeable glyphs, and have zero
+        // `unicode_width`, so `RunAccum::matches` lets one attach to the end
+        // of the preceding run instead of breaking it. Shaping a trailing
+        // tab can then produce a bogus wide advance that gets inserted into
+        // the ligature map, overwriting real characters in the next word.
+        // Flush and exclude tabs entirely rather than let them enter run
+        // text.
+        if cell.c == '\t' {
+            accum.flush(&mut out);
             continue;
         }
 
@@ -1012,7 +1025,10 @@ fn build_ligature_map(runs: &[StyledRun], atlas: &mut GlyphAtlas) -> LigatureMap
             }
 
             // Contextual alternate that fits in a single cell — record it.
-            if atlas.fits_single_cell(glyph.cache_key) {
+            if atlas.fits_single_cell(
+                glyph.cache_key,
+                GlyphStyle { bold: run.bold, italic: run.italic },
+            ) {
                 map.insert(
                     (run.line, col),
                     LigatureCellInfo { cache_key: glyph.cache_key, glyph_span: 1, cell_index: 0 },
@@ -1027,7 +1043,10 @@ fn build_ligature_map(runs: &[StyledRun], atlas: &mut GlyphAtlas) -> LigatureMap
             while shaped.get(i).is_some_and(|g| {
                 g.glyph_span == 1
                     && is_contextual_alternate(atlas, g, run)
-                    && !atlas.fits_single_cell(g.cache_key)
+                    && !atlas.fits_single_cell(
+                        g.cache_key,
+                        GlyphStyle { bold: run.bold, italic: run.italic },
+                    )
             }) {
                 i += 1;
             }
@@ -1060,4 +1079,80 @@ fn build_ligature_map(runs: &[StyledRun], atlas: &mut GlyphAtlas) -> LigatureMap
     }
 
     map
+}
+
+#[cfg(test)]
+mod tests {
+    use alacritty_terminal::index::{Column, Line, Point};
+    use alacritty_terminal::vte::ansi::{Color, NamedColor};
+
+    use super::*;
+
+    fn cell(line: i32, col: usize, c: char) -> CollectedCell {
+        CollectedCell {
+            point: Point::new(Line(line), Column(col)),
+            c,
+            fg: Color::Named(NamedColor::Foreground),
+            bg: Color::Named(NamedColor::Background),
+            flags: Flags::empty(),
+        }
+    }
+
+    /// Builds one row of cells from `text`, assuming every character is
+    /// single-width (sufficient for the ASCII fixtures used below).
+    fn cells_from_str(line: i32, text: &str) -> Vec<CollectedCell> {
+        text.chars().enumerate().map(|(i, c)| cell(line, i, c)).collect()
+    }
+
+    /// BSD `ls`'s columnar output separates entries with raw tabs, not
+    /// spaces. A tab must never end up inside shaped run text.
+    #[test]
+    fn detect_styled_runs_excludes_tabs_from_run_text() {
+        let cells = cells_from_str(0, "tests\tAGENTS.md");
+        let runs = detect_styled_runs(&cells);
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text, "tests");
+        assert_eq!(runs[0].start_col, 0);
+        assert_eq!(runs[1].text, "AGENTS.md");
+        assert_eq!(runs[1].start_col, 6);
+        assert!(runs.iter().all(|r| !r.text.contains('\t')));
+    }
+
+    /// A tab has zero `unicode_width`, so naive column tracking lets it
+    /// attach to the end of the preceding run instead of breaking it.
+    /// Runs must still end exactly at the real text, excluding the tab.
+    #[test]
+    fn detect_styled_runs_flushes_run_on_trailing_tab() {
+        let cells = cells_from_str(0, "=>\tvalue");
+        let runs = detect_styled_runs(&cells);
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text, "=>");
+        assert_eq!(runs[1].text, "value");
+    }
+
+    /// Short names can need multiple tab stops to reach the next column;
+    /// consecutive tabs must not panic or get merged into run text.
+    #[test]
+    fn detect_styled_runs_handles_consecutive_tabs() {
+        let cells = cells_from_str(0, "ab\t\t\tcd");
+        let runs = detect_styled_runs(&cells);
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text, "ab");
+        assert_eq!(runs[1].text, "cd");
+        assert_eq!(runs[1].start_col, 5);
+    }
+
+    /// A lone tab with no adjacent same-run text on either side must not
+    /// surface as a one-character run (runs require >= 2 chars anyway, but
+    /// this pins down the tab-specific flush path doesn't special-case it).
+    #[test]
+    fn detect_styled_runs_drops_lone_leading_tab() {
+        let cells = cells_from_str(0, "\tx");
+        let runs = detect_styled_runs(&cells);
+
+        assert!(runs.is_empty());
+    }
 }

--- a/lat.md/rendering.md
+++ b/lat.md/rendering.md
@@ -18,6 +18,12 @@ If a shaped glyph spans more than one terminal column or is a contextual alterna
 
 `col_offset` counts wide characters as multiple grid columns while `chars` indexes them as one entry, so the two diverge after any wide character. Populating `source_char` from cosmic-text's `g.start..g.end` byte range during shaping keeps identity checks correct regardless of grid position — fixing the false-positive contextual-alternate detection that produced blank cells past emoji on the same run.
 
+#### Tab Exclusion From Run Text
+
+Tab characters are excluded from shaped run text entirely — [[crates/scribe-renderer/src/lib.rs#detect_styled_runs]] flushes the accumulator and skips the cell outright when it encounters `\t`, the same way it already skips wide-char spacer cells.
+
+`unicode_width` gives `\t` a width of 0, so [[crates/scribe-renderer/src/lib.rs#RunAccum#matches]]'s column-matching let a tab silently attach to the end of the preceding run instead of breaking it (e.g. a run's text became `"tests\t"`). Shaping that trailing tab through cosmic-text produced an arbitrary, oversized glyph advance, and since any shaped glyph spanning more than one column is inserted into the ligature map as-is (see above), the bogus span got inserted starting at the tab's own column and ran forward into the next word's real characters, silently replacing their rendered glyphs with slices of the tab's texture. This is the mechanism behind BSD `ls`'s columnar output (which separates entries with raw tabs, not spaces) dropping the first few characters of filenames when ligatures are enabled. [[crates/scribe-renderer/src/lib.rs#TerminalRenderer#resolve_glyph_uv_raw]] and [[crates/scribe-renderer/src/lib.rs#TerminalRenderer#resolve_glyph_uv_for_collected_fields]] also treat `\t` as a blank cell (same as space and NUL) as defense in depth, independent of the run-detection fix. The fix lives entirely in `scribe-renderer`, which has no `cfg(target_os)` branches, so it applies identically on macOS and Linux.
+
 ### Cursor Rendering
 
 Block cursor inverts foreground and background colours. Beam cursor renders the normal cell plus a thin vertical bar overlay. Underline cursor renders the normal cell plus a thin horizontal bar at the bottom.

--- a/lat.md/rendering.md
+++ b/lat.md/rendering.md
@@ -68,6 +68,12 @@ Characters are shaped with cosmic-text and rasterized via the swash cache, then 
 
 Advanced shaping is used for ligatures, Basic when disabled. Mask images are expanded to RGBA by filling white; Color images are kept as-is. Swash placement offsets position the glyph on the canvas.
 
+### Weight-Aware Cell Measurement
+
+Bold glyphs are shaped at a heavier weight than regular text, so the atlas measures a separate reference cell width per weight (`cell_size` and `bold_cell_size`) for ligature classification.
+
+[[crates/scribe-renderer/src/atlas.rs#measure_cell]] shapes an "M" at a given `weight` and records its advance; [[crates/scribe-renderer/src/atlas.rs#GlyphAtlas]] stores both the regular and bold results. Ligature classification compares each shaped glyph against the width for its own weight: [[crates/scribe-renderer/src/atlas.rs#GlyphAtlas#shape_run_uncached]] divides a glyph's advance by the matching cell width to derive its column span, and [[crates/scribe-renderer/src/atlas.rs#GlyphAtlas#fits_single_cell]] bounds a glyph's visual extent against it. Both take the glyph's [[crates/scribe-renderer/src/atlas.rs#GlyphStyle]] so the correct width is chosen. Measuring a legitimately wider bold glyph against the narrower regular-weight "M" previously made an ordinary single-cell bold glyph exceed the threshold and get misclassified as a multi-cell ligature, corrupting the ligature map and dropping the following cell's character.
+
 ### Font Fallbacks
 
 Glyph shaping uses a Scribe-specific cosmic-text fallback list so terminal icon fonts win before generic symbol fonts.


### PR DESCRIPTION
## Problem

With ligatures enabled, bare `ls` output dropped the leading characters of filenames on macOS (e.g. `rustfmt.toml` → `ustfmt.toml`), while `ls -al` and pasted text rendered correctly, and disabling ligatures also masked the bug.

## Root cause

BSD `ls`'s columnar output separates entries with raw **tab bytes**, not space padding.

1. `RunAccum::matches` (`crates/scribe-renderer/src/lib.rs`) predicts the next cell's column using `unicode_width`. A tab has width 0, so a tab cell doesn't break the run-boundary check — it silently attaches to the end of the *preceding* word's run text (e.g. `"tests"` became `"tests\t"`).
2. That run gets shaped through cosmic-text (`Shaping::Advanced`). The trailing tab has no real glyph, and shaping it produced an arbitrary, oversized advance width — glyph spans of 3–8 cells observed via tracing.
3. Any shaped glyph spanning more than one column gets inserted into the ligature map "as-is" in `build_ligature_map`, unconditionally. Since the bogus span was attributed to the tab's own column and extended several columns *forward*, it landed on top of the real characters of the *next* word, overwriting their glyph lookups with slices of the tab's bogus texture.

Verified directly: added tracing that fires whenever a ligature-map entry claims a non-space/tab/NUL cell — it fired exactly on the corrupted letters (`r`, `t`, `e`, `s`, `t`, `d`, `i`, `s`) with glyph spans of 6, 8, and 3, matching the visual corruption precisely.

`scribe-renderer` has zero `cfg(target_os)` branches, so this fix applies identically on macOS and Linux. The trigger isn't macOS-exclusive either — GNU coreutils `ls` on Linux tab-pads by default too (`--tabsize=0` forces spaces), so this was likely latent there as well.

## Fix

1. **Primary**: `detect_styled_runs` now flushes the run accumulator and excludes `\t` entirely from run text, the same treatment already given to wide-char spacer cells.
2. **Defense in depth**: `resolve_glyph_uv_raw` and `resolve_glyph_uv_for_collected_fields` now treat `\t` as a blank cell, identical to space/NUL.

Also includes an independent, pre-existing latent-bug fix found while debugging: bold-weight glyphs were being measured against the regular-weight cell width in `atlas.rs`, which could misclassify legitimate single-cell bold glyphs as multi-cell ligatures. It didn't cause this particular bug but is a real correctness fix, kept in place.

## Tests

- 4 new unit tests in `crates/scribe-renderer/src/lib.rs` covering: tabs excluded from run text, a run correctly flushing on a trailing tab after a ligature sequence, consecutive tabs, and a lone tab with no adjacent text.
- `lat.md/rendering.md` updated with a new "Tab Exclusion From Run Text" subsection documenting the mechanism.
- Verified against the real repro on the reporter's machine: ligatures enabled, bare `ls`, corruption gone.

## Test plan

- [x] `cargo test -p scribe-renderer` (4/4 new tests pass; 2 pre-existing failures are unrelated, missing-font issues confirmed present on unmodified `main` via `git stash`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p scribe-renderer --all-targets --all-features -- -D warnings`
- [x] `lat check`
- [x] Manually verified on the reporting machine: `ls` with ligatures enabled no longer corrupts filenames